### PR TITLE
added container build/push

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:  
+  build_java11:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Configure git
+        run: |
+          git config --global committer.email "noreply@github.com"
+          git config --global committer.name "GitHub"
+          git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global author.name "${GITHUB_ACTOR}"      
+      - name: Build with Maven
+        run: mvn -Pproduction spring-boot:build-image
+        env:
+          CONTAINER_REGISTRY_USERNAME: ${{ secrets.CR_PAT }}        
+          CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CR_PAT }}
+          CONTAINER_REGISTRY_URL: ghcr.io
+          CONTAINER_REPOSITORY: ${GITHUB_REPOSITORY_OWNER}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- Project from https://start.vaadin.com/ -->
     <groupId>com.example.application</groupId>
@@ -17,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.6</version>
+        <version>2.7.0</version>
     </parent>
 
     <repositories>
@@ -209,6 +208,26 @@
                         </executions>
                         <configuration>
                             <productionMode>true</productionMode>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <!-- Clean build and startup time for Vaadin apps sometimes may exceed
+                             the default Spring Boot's 30sec timeout.  -->
+                        <configuration>
+                            <wait>500</wait>
+                            <maxAttempts>240</maxAttempts>
+                            <image>
+                                <name>${env.CONTAINER_REGISTRY_URL}/${env.CONTAINER_REPOSITORY}/hilla-crm/${project.artifactId}:${project.version}</name>
+                                <publish>true</publish>
+                            </image>
+                            <docker>
+                                <publishRegistry>
+                                    <username>${env.CONTAINER_REGISTRY_USERNAME}</username>
+                                    <password>${env.CONTAINER_REGISTRY_PASSWORD}</password>
+                                </publishRegistry>
+                            </docker>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This leverages github actions to build and push the container image.  The personal access token value must be added as CR_PAT as an action secret.  There are also 4 environment variables which would need to be populated if running spring-boot:image-build locally.  They are:
```
CONTAINER_REGISTRY_URL (ghcr.io)
CONTAINER_REPOSITORY (i.e. ivgallo, carljmosca)
CONTAINER_REGISTRY_USERNAME (i.e. vgallo, carljmosca) 
CONTAINER_REGISTRY_PASSWORD (personal access token)
```

As I understand the spring-boot maven plugin it's supposed to support a token instead of a username and password (using token as the password value) but I could not get it to push.  Docs seem to be a bit vague and I noticed other had issues as well.

Is this is a welcome contribution, I would also like to create a Helm chart.